### PR TITLE
Start up postgres and local api server using Apple script #4

### DIFF
--- a/Sources/postgreshelper/ConfigParser.swift
+++ b/Sources/postgreshelper/ConfigParser.swift
@@ -10,10 +10,13 @@ import Foundation
 enum ConfigParser {
     static func parse(from absolutePath: String) -> Config {
         let configURL = URL(fileURLWithPath: absolutePath)
-
-        guard let configData = try? Data(contentsOf: configURL),
-              let config = try? JSONDecoder().decode(Config.self, from: configData) else {
+        let config: Config
+        do {
+            let configData = try Data(contentsOf: configURL)
+            config = try JSONDecoder().decode(Config.self, from: configData)
+        } catch {
             print("❌ Failed to parse config")
+            print("- \(error.localizedDescription)")
             exit(1)
         }
 

--- a/Sources/postgreshelper/LauncherProtocol.swift
+++ b/Sources/postgreshelper/LauncherProtocol.swift
@@ -1,0 +1,22 @@
+//
+//  LauncherProtocol.swift
+//  
+//
+//  Created by Amanuel Ketebo on 12/19/20.
+//
+
+import Foundation
+
+protocol LauncherProtocol {
+    func launch(process: Process) throws
+}
+
+extension LauncherProtocol {
+    func launch(process: Process) throws {
+        if #available(OSX 10.13, *) {
+            try process.run()
+        } else {
+            process.launch()
+        }
+    }
+}

--- a/Sources/postgreshelper/LocalDriveServer.swift
+++ b/Sources/postgreshelper/LocalDriveServer.swift
@@ -1,0 +1,38 @@
+//
+//  LocalDriveServer.swift
+//  
+//
+//  Created by Amanuel Ketebo on 12/19/20.
+//
+
+import Foundation
+
+class LocalDriveAPIServer {
+    let config: Config
+
+    init(config: Config) {
+        self.config = config
+    }
+
+    func startServer() {
+        let process = Process()
+
+        process.launchPath = "/usr/bin/osascript"
+        process.arguments = ["-e", "tell app \"Terminal\" to do script \"cd \(config.driveAPIRepo.repoAbsolutePath) && npm start\""]
+
+        do {
+            try launch(process: process)
+        } catch {
+            print("❌ Failed to start server")
+            exit(1)
+        }
+    }
+
+    private func launch(process: Process) throws {
+        if #available(OSX 10.13, *) {
+            try process.run()
+        } else {
+            process.launch()
+        }
+    }
+}

--- a/Sources/postgreshelper/LocalDriveServer.swift
+++ b/Sources/postgreshelper/LocalDriveServer.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class LocalDriveAPIServer {
+class LocalDriveAPIServer: LauncherProtocol {
     let config: Config
 
     init(config: Config) {
@@ -25,14 +25,6 @@ class LocalDriveAPIServer {
         } catch {
             print("❌ Failed to start server")
             exit(1)
-        }
-    }
-
-    private func launch(process: Process) throws {
-        if #available(OSX 10.13, *) {
-            try process.run()
-        } else {
-            process.launch()
         }
     }
 }

--- a/Sources/postgreshelper/PostgresDatabase.swift
+++ b/Sources/postgreshelper/PostgresDatabase.swift
@@ -48,8 +48,11 @@ class PostgresDatabase {
     // MARK: - Start
 
     func startServer() {
-        let process = newServerProcess()
+        let process = Process()
 
+        process.launchPath = "/usr/bin/osascript"
+        process.arguments = ["-e", "tell app \"Terminal\" to do script \"psql -d \(config.postgres.localDatabase.databaseName) -U \(config.postgres.localDatabase.username)\""]
+        
         do {
             try launch(process: process)
         } catch {

--- a/Sources/postgreshelper/PostgresDatabase.swift
+++ b/Sources/postgreshelper/PostgresDatabase.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class PostgresDatabase {
+class PostgresDatabase: LauncherProtocol {
 
     // MARK: - Properties
 
@@ -69,13 +69,5 @@ class PostgresDatabase {
         process.arguments = ["-d", "\(config.postgres.localDatabase.databaseName)",
                              "-U", "\(config.postgres.localDatabase.username)"]
         return process
-    }
-
-    private func launch(process: Process) throws {
-        if #available(OSX 10.13, *) {
-            try process.run()
-        } else {
-            process.launch()
-        }
     }
 }

--- a/Sources/postgreshelper/main.swift
+++ b/Sources/postgreshelper/main.swift
@@ -5,6 +5,7 @@ let config = ConfigParser.parse(from: sourceRootAbsolutePath + "/postgres-local-
 let postgresDatabase = PostgresDatabase(config: config)
 let buildScriptChecker = BuildScriptChecker(config: config,
                                             sourceRootAbsolutePath: sourceRootAbsolutePath)
+let localDriveAPIServer = LocalDriveAPIServer(config: config)
 
 if buildScriptChecker.shouldUpdateTables() {
     if !buildScriptChecker.savedBuildScriptString().isEmpty {
@@ -14,3 +15,6 @@ if buildScriptChecker.shouldUpdateTables() {
     postgresDatabase.addTables()
     buildScriptChecker.saveCurrentBuildScriptString()
 }
+
+postgresDatabase.startServer()
+localDriveAPIServer.startServer()


### PR DESCRIPTION
Uses Apple script, `osascript`, to open terminals to start postgres and local api server.

I think there's more stuff we'll need to look out for like:
* What happens if there are multiple terminals open all running the same servers 🤔.
* At the moment the local api server isn't starting up because I think a config is missing? Looking into that next.