### PR TITLE
Add apple script for closing terminal that's running server

### DIFF
--- a/Sources/postgreshelper/close-terminal.applescript
+++ b/Sources/postgreshelper/close-terminal.applescript
@@ -1,16 +1,16 @@
 on run (windowID)
 	tell application "Terminal"
         # Close window with passed in windowID
-		close (every window whose id is windowID)
-		delay 2
+        close (every window whose id is windowID)
+        delay 2
 
         # Move Terminal window to foreground
         activate
         delay 2
 
         # Click on confirm button for closing Terminal
-		tell application "System Events"
-			click UI element "Terminate" of sheet 1 of window 1 of application process "Terminal"
-		end tell
-	end tell
+        tell application "System Events"
+            click UI element "Terminate" of sheet 1 of window 1 of application process "Terminal"
+        end tell
+    end tell
 end run

--- a/Sources/postgreshelper/close-terminal.applescript
+++ b/Sources/postgreshelper/close-terminal.applescript
@@ -1,0 +1,16 @@
+on run (windowID)
+	tell application "Terminal"
+        # Close window with passed in windowID
+		close (every window whose id is windowID)
+		delay 2
+
+        # Move Terminal window to foreground
+        activate
+        delay 2
+
+        # Click on confirm button for closing Terminal
+		tell application "System Events"
+			click UI element "Terminate" of sheet 1 of window 1 of application process "Terminal"
+		end tell
+	end tell
+end run


### PR DESCRIPTION
Context:
Before we start the local drive api server, we'll need to make sure the old one isn't running

* Add AppleScript that will close terminal running server
* Still need to work on saving the `windowID` and actually running the script